### PR TITLE
Fix ACE medical respawn healing

### DIFF
--- a/hq_respawn_system.sqf
+++ b/hq_respawn_system.sqf
@@ -61,9 +61,14 @@ HQ_InitRespawn = {
                     player setVelocity [0, 0, 0];
                 };
 
-                if (isClass (configFile >> "CfgPatches" >> "ace_medical")) then {
+                // Heal the player after respawn
+                if (!isNil "ace_medical_treatment_fnc_fullHealLocal") then {
+                    // Use ACE medical if available
                     [player] call ace_medical_treatment_fnc_fullHealLocal;
+                    // Make sure the unit is conscious again
+                    [player, false] call ace_medical_fnc_setUnconscious;
                 } else {
+                    // Vanilla fallback
                     player setDamage 0;
                     player setBleedingRemaining 0;
                     player setFatigue 0;


### PR DESCRIPTION
## Summary
- ensure ACE medical full-heal is used on respawn when available
- force players to wake up after ACE heal so they don't remain unconscious

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_68a7a1a7f6a883298c8e6e0427600ce2