### PR TITLE
Fix per-frame handler arguments for CBA

### DIFF
--- a/hq_marker_system.sqf
+++ b/hq_marker_system.sqf
@@ -99,6 +99,7 @@ HQ_StartUpdateLoop = {
                 diag_log "HQ Marker System: Update loop terminated";
             };
         },
+        [],
         HQ_UPDATE_INTERVAL
     ] call CBA_fnc_addPerFrameHandler;
 };

--- a/hq_respawn_system.sqf
+++ b/hq_respawn_system.sqf
@@ -116,6 +116,7 @@ HQ_UpdateRespawnPosition = {
                     "respawn_guerrila" setMarkerPos (getPosATL flag_fob);
                 };
             },
+            [],
             10
         ] call CBA_fnc_addPerFrameHandler;
     },


### PR DESCRIPTION
## Summary
- correct CBA_fnc_addPerFrameHandler usage in HQ marker update loop
- supply empty argument array in HQ respawn system's per-frame handler

## Testing
- `sqflint hq_marker_system.sqf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a80870788329aaff6b435d7dbaea