### PR TITLE
Fix CBA per-frame handler parameter order

### DIFF
--- a/hq_marker_system.sqf
+++ b/hq_marker_system.sqf
@@ -99,8 +99,8 @@ HQ_StartUpdateLoop = {
                 diag_log "HQ Marker System: Update loop terminated";
             };
         },
-        [],
-        HQ_UPDATE_INTERVAL
+        HQ_UPDATE_INTERVAL,
+        []
     ] call CBA_fnc_addPerFrameHandler;
 };
 

--- a/hq_respawn_system.sqf
+++ b/hq_respawn_system.sqf
@@ -117,8 +117,8 @@ HQ_UpdateRespawnPosition = {
                     "respawn_guerrila" setMarkerPos (getPosATL flag_fob);
                 };
             },
-            [],
-            10
+            10,
+            []
         ] call CBA_fnc_addPerFrameHandler;
     },
     []


### PR DESCRIPTION
## Summary
- fix parameter order for CBA_fnc_addPerFrameHandler in respawn system
- fix parameter order for CBA_fnc_addPerFrameHandler in marker system

## Testing
- `echo "No automated tests available" && date`


------
https://chatgpt.com/codex/tasks/task_e_68a7b35be2688329b2997b5c883482f7