### PR TITLE
Revert CBA integration

### DIFF
--- a/hq_local_movement.sqf
+++ b/hq_local_movement.sqf
@@ -77,7 +77,7 @@ HQ_StartLocalMovement = {
         if (_object == clipboard_fob) then {
             call HQ_InitLocalMovement; // Refresh clipboard actions
         };
-        if (_object == arsenal_fob && {isClass (configFile >> "CfgPatches" >> "ace_arsenal")}) then {
+        if (_object == arsenal_fob) then {
             [_object, true] call ace_arsenal_fnc_initBox; // Refresh arsenal
         };
         

--- a/init.sqf
+++ b/init.sqf
@@ -1,9 +1,7 @@
 // Define functions first
 HQ_Init = {
-    // Setup ACE Arsenal if available
-    if (isClass (configFile >> "CfgPatches" >> "ace_arsenal")) then {
-        [arsenal_fob, true] call ace_arsenal_fnc_initBox;
-    };
+    // Setup ACE Arsenal
+    [arsenal_fob, true] call ace_arsenal_fnc_initBox;
     
     // Remove only HQ relocation actions from clipboard to prevent duplicates
     // Use a flag to track if we've already added the HQ relocation action
@@ -86,9 +84,8 @@ execVM "hq_respawn_system.sqf";
 execVM "hq_marker_system.sqf";
 
 if (hasInterface) then {
-    [
-        { !isNull player && alive player && {!isNil "ace_interact_menu_fnc_createAction"} },
-        { [] call RPG_fnc_initPlayer; },
-        []
-    ] call CBA_fnc_waitUntilAndExecute;
+  [] spawn {
+    waitUntil { !isNull player && alive player && {!isNil "ace_interact_menu_fnc_createAction"} };
+    [] call RPG_fnc_initPlayer;
+  };
 };


### PR DESCRIPTION
## Summary
- Revert HQ marker, respawn, and init scripts to versions without CBA dependencies
- Restore manual spawn loops and native event handlers
- Simplify local movement arsenal refresh

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b6dfb0808329b1ef7a6692367a5d