### PR TITLE
Add persistent RPG skill system with ACE interaction menu

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -7,3 +7,15 @@ class Header
 
 respawn = 3;
 respawnDelay = 5;
+
+class CfgRemoteExec
+{
+    class Functions
+    {
+        mode = 2;
+        jip = 1;
+        class RPG_fnc_requestStats { allowedTargets = 2; };
+        class RPG_fnc_changeSkill { allowedTargets = 2; };
+        class RPG_fnc_applyStats { allowedTargets = 1; };
+    };
+};

--- a/init.sqf
+++ b/init.sqf
@@ -83,6 +83,12 @@ execVM "hq_local_movement.sqf";
 execVM "hq_respawn_system.sqf";
 execVM "hq_marker_system.sqf";
 
+[] execVM "rpg_skill_system.sqf";
+if (isServer) then {
+    [] call RPG_fnc_initServer;
+};
+
+
 if (hasInterface) then {
   [] spawn {
     waitUntil { !isNull player && alive player && {!isNil "ace_interact_menu_fnc_createAction"} };

--- a/rpg_skill_system.sqf
+++ b/rpg_skill_system.sqf
@@ -1,0 +1,124 @@
+// Basic RPG skill system with ACE integration and persistence
+
+RPG_DEFAULT_STATS = [1,1,1,1];
+RPG_MAX_LEVEL = 5;
+
+// Server initialization: load saved stats
+RPG_fnc_initServer = {
+    RPG_PlayerStats = profileNamespace getVariable ["RPG_PlayerStats", []];
+    if (isNil "RPG_PlayerStats") then {RPG_PlayerStats = []};
+};
+
+// Save stats to profileNamespace
+RPG_fnc_saveStats = {
+    profileNamespace setVariable ["RPG_PlayerStats", RPG_PlayerStats];
+    saveProfileNamespace;
+};
+
+// Get entry for UID
+RPG_fnc_getEntry = {
+    params ["_uid"];
+    {
+        if ((_x select 0) isEqualTo _uid) exitWith { _x };
+    } forEach RPG_PlayerStats;
+};
+
+// Server: client requests stats
+RPG_fnc_requestStats = {
+    params ["_player", "_uid"];
+    private _entry = [_uid] call RPG_fnc_getEntry;
+    if (isNil "_entry") then {
+        _entry = [_uid] + RPG_DEFAULT_STATS;
+        RPG_PlayerStats pushBack _entry;
+        [] call RPG_fnc_saveStats;
+    };
+    [_entry] remoteExec ["RPG_fnc_applyStats", _player];
+};
+
+// Server: change a skill value
+RPG_fnc_changeSkill = {
+    params ["_uid", "_skillIndex", "_delta"];
+    private _entry = [_uid] call RPG_fnc_getEntry;
+    if (isNil "_entry") then {
+        _entry = [_uid] + RPG_DEFAULT_STATS;
+        RPG_PlayerStats pushBack _entry;
+    };
+    private _val = (_entry select _skillIndex) + _delta;
+    _val = _val max 1 min RPG_MAX_LEVEL;
+    _entry set [_skillIndex, _val];
+    [] call RPG_fnc_saveStats;
+    private _plr = [_uid] call BIS_fnc_getUnitByUID;
+    if (!isNull _plr) then {
+        [_entry] remoteExec ["RPG_fnc_applyStats", _plr];
+    };
+};
+
+// Client: apply stats received from server
+RPG_fnc_applyStats = {
+    params ["_entry"];
+    private _stats = _entry select [1,4];
+    player setVariable ["RPG_stats", _stats];
+    [player] call RPG_fnc_updateTraits;
+};
+
+// Apply traits to unit based on stats
+RPG_fnc_updateTraits = {
+    params ["_unit"];
+    private _stats = _unit getVariable ["RPG_stats", RPG_DEFAULT_STATS];
+    private _endurance = _stats select 0;
+    private _carry = _stats select 1;
+    private _speed = _stats select 2;
+    private _accuracy = _stats select 3;
+
+    // Damage reduction via HandleDamage event
+    if (isNil {_unit getVariable "RPG_hdEH"}) then {
+        _unit setVariable ["RPG_hdEH", _unit addEventHandler ["HandleDamage", {
+            params ["_u", "", "_d"];
+            private _st = _u getVariable ["RPG_stats", RPG_DEFAULT_STATS];
+            private _end = _st select 0;
+            private _mult = 1 - ((_end - 1) * 0.05);
+            _d * _mult;
+        }]];
+    };
+
+    // Carry capacity modifier
+    _unit setUnitTrait ["loadCoef", 1 - ((_carry - 1) * 0.05)];
+
+    // Movement speed modifier
+    _unit setAnimSpeedCoef (1 + ((_speed - 1) * 0.05));
+
+    // Accuracy modifier
+    _unit setCustomAimCoef (1 - ((_accuracy - 1) * 0.05));
+};
+
+// Display current stats
+RPG_fnc_showStats = {
+    private _s = player getVariable ["RPG_stats", RPG_DEFAULT_STATS];
+    hint format ["Endurance: %1\nCarry: %2\nSpeed: %3\nAccuracy: %4", _s select 0, _s select 1, _s select 2, _s select 3];
+};
+
+// Client: request server to change skill
+RPG_fnc_changeSkillRequest = {
+    params ["_skill", "_delta"];
+    [getPlayerUID player, _skill + 1, _delta] remoteExec ["RPG_fnc_changeSkill", 2];
+};
+
+// Client initialization
+RPG_fnc_initPlayer = {
+    [player, getPlayerUID player] remoteExec ["RPG_fnc_requestStats", 2];
+
+    private _root = ["RPG_root", "RPG Skills", "", {}, {true}] call ace_interact_menu_fnc_createAction;
+    [player, 1, ["ACE_SelfActions"], _root] call ace_interact_menu_fnc_addActionToObject;
+
+    private _view = ["RPG_view", "View Skills", "", {[] call RPG_fnc_showStats}, {true}] call ace_interact_menu_fnc_createAction;
+    [player, 1, ["ACE_SelfActions", "RPG_root"], _view] call ace_interact_menu_fnc_addActionToObject;
+
+    {
+        private _idx = _forEachIndex;
+        private _name = _x;
+        private _inc = [format ["RPG_inc_%1", _name], format ["Increase %1", _name], "", { [_idx, 1] call RPG_fnc_changeSkillRequest }, {true}] call ace_interact_menu_fnc_createAction;
+        [player, 1, ["ACE_SelfActions", "RPG_root"], _inc] call ace_interact_menu_fnc_addActionToObject;
+        private _dec = [format ["RPG_dec_%1", _name], format ["Decrease %1", _name], "", { [_idx, -1] call RPG_fnc_changeSkillRequest }, {true}] call ace_interact_menu_fnc_createAction;
+        [player, 1, ["ACE_SelfActions", "RPG_root"], _dec] call ace_interact_menu_fnc_addActionToObject;
+    } forEach ["Endurance", "Carry", "Speed", "Accuracy"];
+};


### PR DESCRIPTION
## Summary
- Add RPG skill system with endurance, carry, speed, and accuracy modifiers
- Persist player stats across sessions using server profileNamespace
- Integrate skill viewing and modification into ACE self-interaction menu

## Testing
- `rg -l '\btest\b'` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a7be11cb988329a169bee250c4db61