### PR TITLE
Fix ACE invulnerability after respawn

### DIFF
--- a/hq_respawn_system.sqf
+++ b/hq_respawn_system.sqf
@@ -78,6 +78,8 @@ HQ_InitRespawn = {
                 if (isClass (configFile >> "CfgPatches" >> "ace_medical")) then {
                     // ACE3 Medical full heal - this handles everything
                     [player] call ace_medical_treatment_fnc_fullHealLocal;
+                    // Ensure ACE doesn't keep players invulnerable after respawn
+                    player setVariable ["ace_medical_preventInstaDeath", false, true];
                 } else {
                     // Fallback for vanilla medical or other medical systems
                     player setDamage 0;


### PR DESCRIPTION
## Summary
- ensure ACE medical re-enables death after respawn

## Testing
- `sqflint hq_respawn_system.sqf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d9730ac88329bb1ab0535e876cd7