### PR TITLE
Award XP for kills and remove skill downgrades

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -15,7 +15,7 @@ class CfgRemoteExec
         mode = 2;
         jip = 1;
         class RPG_fnc_requestStats { allowedTargets = 2; };
-        class RPG_fnc_changeSkill { allowedTargets = 2; };
+        class RPG_fnc_increaseSkill { allowedTargets = 2; };
         class RPG_fnc_applyStats { allowedTargets = 1; };
     };
 };


### PR DESCRIPTION
## Summary
- Track XP and skill points for each player
- Grant XP on kills and spend points to increase skills
- Remove skill decrease options from ACE interaction menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cffd92c08329b452338fcc821fb9